### PR TITLE
Cgt 1649 - Created the subscription call to the backend for ghost non-resident individual/no known NINO

### DIFF
--- a/app/connectors/SubscriptionConnector.scala
+++ b/app/connectors/SubscriptionConnector.scala
@@ -22,6 +22,7 @@ import uk.gov.hmrc.play.config.ServicesConfig
 import uk.gov.hmrc.play.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.play.http.ws.WSHttp
 import play.api.http.Status._
+import play.api.libs.json.Json
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -43,7 +44,8 @@ class SubscriptionConnector @Inject()(http: WSHttp) extends ServicesConfig {
   }
 
   def getSubscriptionResponseGhost(fullDetails: FullDetails)(implicit hc: HeaderCarrier): Future[Option[SubscriptionReference]] = {
-    val getUrl =s"""$serviceUrl/$subscriptionUrl/$fullDetails""".stripMargin
+    val stringOfJson = Json.toJson(fullDetails).toString()
+    val getUrl =s"""$serviceUrl/$subscriptionUrl/$stringOfJson""".stripMargin
     http.GET[HttpResponse](getUrl).map{
       response =>
         response.status match {

--- a/app/connectors/SubscriptionConnector.scala
+++ b/app/connectors/SubscriptionConnector.scala
@@ -17,11 +17,12 @@
 package connectors
 
 import com.google.inject.Inject
-import models.SubscriptionReference
+import models.{FullDetails, SubscriptionReference}
 import uk.gov.hmrc.play.config.ServicesConfig
 import uk.gov.hmrc.play.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.play.http.ws.WSHttp
 import play.api.http.Status._
+
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -40,4 +41,17 @@ class SubscriptionConnector @Inject()(http: WSHttp) extends ServicesConfig {
         }
     }
   }
+
+  def getSubscriptionResponseGhost(fullDetails: FullDetails)(implicit hc: HeaderCarrier): Future[Option[SubscriptionReference]] = {
+    val getUrl =s"""$serviceUrl/$subscriptionUrl/$fullDetails""".stripMargin
+    http.GET[HttpResponse](getUrl).map{
+      response =>
+        response.status match {
+          case OK =>
+            Some(response.json.as[SubscriptionReference])
+          case _=> None
+        }
+    }
+  }
+
 }

--- a/app/models/FullDetails.scala
+++ b/app/models/FullDetails.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json.{Json, OFormat}
+
+case class FullDetails(firstName: String,
+                       lastName: String,
+                       addressLineOne: String,
+                       addressLineTwo: String,
+                       townOrCity: String,
+                       county: String,
+                       postCode: String,
+                       Country: String)
+
+object FullDetails {
+  implicit val formats: OFormat[FullDetails] = Json.format[FullDetails]
+}

--- a/test/connectors/SubscriptionConnectorSpec.scala
+++ b/test/connectors/SubscriptionConnectorSpec.scala
@@ -17,7 +17,7 @@
 package connectors
 
 import builders.TestUserBuilder
-import models.SubscriptionReference
+import models.{FullDetails, SubscriptionReference}
 import org.mockito.ArgumentMatchers
 import org.scalatest.mock.MockitoSugar
 import play.api.libs.json.{JsValue, Json}
@@ -69,6 +69,42 @@ class SubscriptionConnectorSpec extends UnitSpec with MockitoSugar with WithFake
 
     "return None" in {
         result shouldBe None
+    }
+  }
+
+  "SubscriptionConnecter .getSubscriptionResponseGhost with a valid request" should {
+    val dummyRef = "CGT-2134"
+
+    val model = FullDetails("john", "smith", "addressLineOne",
+      "addressLineTwo", "town", "county", "postcode", "country")
+
+    when(mockHttp.GET[HttpResponse](ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any()))
+      .thenReturn(Future.successful(HttpResponse(OK, Some(cgtSubscriptionResponse(dummyRef)))))
+
+    val result = await(target.getSubscriptionResponseGhost((model)))
+
+    "return a valid SubscriptionReference" in {
+      result.get shouldBe a[SubscriptionReference]
+    }
+
+    s"return a SubscriptionReference containing the reference ${dummyRef}" in {
+      result.get.cgtRef shouldBe dummyRef
+    }
+  }
+
+  "SubscriptionConnector .getSubscriptionResponse with an invalid request" should {
+    val dummyRef = "CGT-2134"
+
+    val model = FullDetails("name of an invalid character length", "smith", "addressLineOne",
+      "addressLineTwo", "town", "county", "postcode", "country")
+
+    when(mockHttp.GET[HttpResponse](ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any()))
+      .thenReturn(Future.successful(HttpResponse(BAD_REQUEST, Some(Json.toJson("invalid:n")))))
+
+    val result = await(target.getSubscriptionResponseGhost(model))
+
+    "return None" in {
+      result shouldBe None
     }
   }
 

--- a/test/connectors/SubscriptionConnectorSpec.scala
+++ b/test/connectors/SubscriptionConnectorSpec.scala
@@ -92,7 +92,7 @@ class SubscriptionConnectorSpec extends UnitSpec with MockitoSugar with WithFake
     }
   }
 
-  "SubscriptionConnector .getSubscriptionResponse with an invalid request" should {
+  "SubscriptionConnector .getSubscriptionResponseGhost with an invalid request" should {
     val dummyRef = "CGT-2134"
 
     val model = FullDetails("name of an invalid character length", "smith", "addressLineOne",


### PR DESCRIPTION
This might need to be changed subject to a team discussion as to how the full details will be sent (e.g as a parameter in the URL [current solution] or as JSON in the header carrier)