### PR TITLE
Test package refactor

### DIFF
--- a/app/auth/AuthorisedActions.scala
+++ b/app/auth/AuthorisedActions.scala
@@ -23,7 +23,6 @@ import connectors.FrontendAuthorisationConnector
 import play.api.mvc.{Action, AnyContent}
 import predicates._
 import services.AuthorisationService
-import types.{AuthenticatedAgentAction, AuthenticatedIndividualAction, AuthenticatedNROrganisationAction}
 import uk.gov.hmrc.play.frontend.auth.connectors.domain.Accounts
 import uk.gov.hmrc.play.frontend.auth.{Actions, AuthContext, AuthenticationProvider, TaxRegime}
 

--- a/app/auth/package.scala
+++ b/app/auth/package.scala
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-import auth.{CgtAgent, CgtIndividual, CgtNROrganisation}
 import play.api.mvc.{AnyContent, Request, Result}
 
 import scala.concurrent.Future
 
-package object types {
+package object auth {
   type AuthenticatedIndividualAction = CgtIndividual => Request[AnyContent] => Future[Result]
   type AuthenticatedNROrganisationAction = CgtNROrganisation => Request[AnyContent] => Future[Result]
   type AuthenticatedAgentAction = CgtAgent => Request[AnyContent] => Future[Result]

--- a/app/common/IdentityVerificationResult.scala
+++ b/app/common/IdentityVerificationResult.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package enums
+package common
 
 import play.api.Logger
 import play.api.libs.json._

--- a/app/connectors/IdentityVerificationConnector.scala
+++ b/app/connectors/IdentityVerificationConnector.scala
@@ -18,7 +18,7 @@ package connectors
 
 import javax.inject.{Inject, Singleton}
 import config.WSHttp
-import enums.IdentityVerificationResult.IdentityVerificationResult
+import common.IdentityVerificationResult.IdentityVerificationResult
 import play.api.libs.json.Json
 import uk.gov.hmrc.play.config.ServicesConfig
 import uk.gov.hmrc.play.http.{HeaderCarrier, HttpResponse}

--- a/app/services/IdentityVerificationService.scala
+++ b/app/services/IdentityVerificationService.scala
@@ -18,7 +18,7 @@ package services
 
 import javax.inject.{Inject, Singleton}
 import connectors.IdentityVerificationConnector
-import enums.IdentityVerificationResult._
+import common.IdentityVerificationResult._
 import uk.gov.hmrc.play.http.HeaderCarrier
 
 import scala.concurrent.Future

--- a/test/connectors/AuthorisationConnectorSpec.scala
+++ b/test/connectors/AuthorisationConnectorSpec.scala
@@ -22,7 +22,7 @@ import data.TestUserBuilder
 import models.{AuthorisationDataModel, Enrolment, Identifier}
 import org.scalatest.mock.MockitoSugar
 import play.api.libs.json.{JsValue, Json}
-import uk.gov.hmrc.play.http.{HeaderCarrier, HttpGet, HttpPost, HttpResponse}
+import uk.gov.hmrc.play.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.when

--- a/test/connectors/AuthorisationConnectorSpec.scala
+++ b/test/connectors/AuthorisationConnectorSpec.scala
@@ -16,9 +16,9 @@
 
 package connectors
 
-import builders.TestUserBuilder
 import common.Constants.AffinityGroup
 import config.WSHttp
+import data.TestUserBuilder
 import models.{AuthorisationDataModel, Enrolment, Identifier}
 import org.scalatest.mock.MockitoSugar
 import play.api.libs.json.{JsValue, Json}

--- a/test/connectors/IdentityVerificationConnectorSpec.scala
+++ b/test/connectors/IdentityVerificationConnectorSpec.scala
@@ -16,8 +16,8 @@
 
 package connectors
 
+import common.IdentityVerificationResult
 import config.WSHttp
-import enums.IdentityVerificationResult
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar

--- a/test/connectors/KeystoreConnectorSpec.scala
+++ b/test/connectors/KeystoreConnectorSpec.scala
@@ -18,12 +18,12 @@ package connectors
 
 import java.util.UUID
 
-import assets.ControllerTestSpec
 import config.{AppConfig, BusinessCustomerSessionCache, SubscriptionSessionCache, WSHttp}
 import models.ReviewDetails
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import play.api.libs.json.Json
+import traits.ControllerTestSpec
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.http.HeaderCarrier
 import uk.gov.hmrc.play.http.logging.SessionId

--- a/test/connectors/SubscriptionConnectorSpec.scala
+++ b/test/connectors/SubscriptionConnectorSpec.scala
@@ -16,13 +16,13 @@
 
 package connectors
 
-import builders.TestUserBuilder
 import models.{AgentSubmissionModel, CompanySubmissionModel, SubscriptionReference, UserFactsModel}
 import org.mockito.ArgumentMatchers
 import org.scalatest.mock.MockitoSugar
 import play.api.libs.json.{JsValue, Json}
 import uk.gov.hmrc.play.http.{HeaderCarrier, HttpResponse}
 import config.{AppConfig, WSHttp}
+import data.TestUserBuilder
 import org.mockito.Mockito._
 import play.api.http.Status._
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}

--- a/test/controllers/AgentControllerSpec.scala
+++ b/test/controllers/AgentControllerSpec.scala
@@ -18,14 +18,13 @@ package controllers
 
 import java.time.LocalDate
 
-import assets.MessageLookup.{AgentConfirmation => messages}
-import assets.{ControllerTestSpec, MessageLookup}
+import data.MessageLookup.{AgentConfirmation => messages}
 import auth.{AuthorisedActions, CgtAgent}
-import builders.TestUserBuilder
 import common.Constants.AffinityGroup
 import common.{Dates, Keys}
 import config.WSHttp
 import connectors._
+import data.{MessageLookup, TestUserBuilder}
 import helpers.EnrolmentToCGTCheck
 import models._
 import org.jsoup.Jsoup
@@ -39,6 +38,7 @@ import play.api.mvc.{Action, AnyContent, Results}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.{AgentService, AuthorisationService, SubscriptionService}
+import traits.ControllerTestSpec
 import types._
 import uk.gov.hmrc.play.frontend.auth.AuthContext
 import uk.gov.hmrc.play.frontend.auth.connectors.domain.{Accounts, ConfidenceLevel, CredentialStrength}

--- a/test/controllers/AgentControllerSpec.scala
+++ b/test/controllers/AgentControllerSpec.scala
@@ -39,7 +39,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.{AgentService, AuthorisationService, SubscriptionService}
 import traits.ControllerTestSpec
-import types._
+import auth._
 import uk.gov.hmrc.play.frontend.auth.AuthContext
 import uk.gov.hmrc.play.frontend.auth.connectors.domain.{Accounts, ConfidenceLevel, CredentialStrength}
 import uk.gov.hmrc.play.http.HeaderCarrier

--- a/test/controllers/CGTSubscriptionControllerSpec.scala
+++ b/test/controllers/CGTSubscriptionControllerSpec.scala
@@ -17,7 +17,7 @@
 package controllers
 
 import config.AppConfig
-import assets.MessageLookup.{CGTSubscriptionConfirm => messages}
+import data.MessageLookup.{CGTSubscriptionConfirm => messages}
 import org.jsoup._
 import org.scalatest.mock.MockitoSugar
 import play.api.http.Status

--- a/test/controllers/CompanyControllerSpec.scala
+++ b/test/controllers/CompanyControllerSpec.scala
@@ -16,13 +16,12 @@
 
 package controllers
 
-import assets.ControllerTestSpec
 import auth.{AuthorisedActions, CgtNROrganisation}
-import builders.TestUserBuilder
 import common.Constants.AffinityGroup
 import common.Keys
 import config.WSHttp
 import connectors.AuthorisationConnector
+import data.TestUserBuilder
 import helpers.EnrolmentToCGTCheck
 import models.{AuthorisationDataModel, Enrolment}
 import org.mockito.ArgumentMatchers
@@ -34,6 +33,7 @@ import play.api.mvc.{Action, AnyContent, Results}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.AuthorisationService
+import traits.ControllerTestSpec
 import types.AuthenticatedNROrganisationAction
 import uk.gov.hmrc.play.frontend.auth.AuthContext
 import uk.gov.hmrc.play.frontend.auth.connectors.domain.{Accounts, ConfidenceLevel, CredentialStrength}

--- a/test/controllers/CompanyControllerSpec.scala
+++ b/test/controllers/CompanyControllerSpec.scala
@@ -34,7 +34,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.AuthorisationService
 import traits.ControllerTestSpec
-import types.AuthenticatedNROrganisationAction
+import auth.AuthenticatedNROrganisationAction
 import uk.gov.hmrc.play.frontend.auth.AuthContext
 import uk.gov.hmrc.play.frontend.auth.connectors.domain.{Accounts, ConfidenceLevel, CredentialStrength}
 

--- a/test/controllers/ContactDetailsControllerSpec.scala
+++ b/test/controllers/ContactDetailsControllerSpec.scala
@@ -30,7 +30,7 @@ import play.api.mvc.{Action, AnyContent, Results}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import traits.ControllerTestSpec
-import types._
+import auth._
 import uk.gov.hmrc.play.frontend.auth.AuthContext
 
 import scala.concurrent.Future

--- a/test/controllers/ContactDetailsControllerSpec.scala
+++ b/test/controllers/ContactDetailsControllerSpec.scala
@@ -16,10 +16,9 @@
 
 package controllers
 
-import assets.{ControllerTestSpec, MessageLookup}
 import auth.{AuthorisedActions, CgtNROrganisation}
-import builders.TestUserBuilder
 import connectors.KeystoreConnector
+import data.{MessageLookup, TestUserBuilder}
 import forms.ContactDetailsForm
 import models.ContactDetailsModel
 import org.jsoup.Jsoup
@@ -30,6 +29,7 @@ import org.mockito.stubbing.Answer
 import play.api.mvc.{Action, AnyContent, Results}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import traits.ControllerTestSpec
 import types._
 import uk.gov.hmrc.play.frontend.auth.AuthContext
 

--- a/test/controllers/CorrespondenceAddressConfirmControllerSpec.scala
+++ b/test/controllers/CorrespondenceAddressConfirmControllerSpec.scala
@@ -16,8 +16,7 @@
 
 package controllers
 
-import assets.ControllerTestSpec
-import assets.MessageLookup.{UseRegisteredAddress => messages}
+import data.MessageLookup.{UseRegisteredAddress => messages}
 import auth.{AuthorisedActions, CgtNROrganisation}
 import common.Keys.KeystoreKeys
 import connectors.KeystoreConnector
@@ -32,6 +31,7 @@ import org.mockito.stubbing.Answer
 import play.api.mvc.{Action, AnyContent, Results}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import traits.ControllerTestSpec
 import types.AuthenticatedNROrganisationAction
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.frontend.auth.AuthContext

--- a/test/controllers/CorrespondenceAddressConfirmControllerSpec.scala
+++ b/test/controllers/CorrespondenceAddressConfirmControllerSpec.scala
@@ -32,7 +32,7 @@ import play.api.mvc.{Action, AnyContent, Results}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import traits.ControllerTestSpec
-import types.AuthenticatedNROrganisationAction
+import auth.AuthenticatedNROrganisationAction
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.play.frontend.auth.AuthContext
 

--- a/test/controllers/CorrespondenceAddressFinalConfirmationControllerSpec.scala
+++ b/test/controllers/CorrespondenceAddressFinalConfirmationControllerSpec.scala
@@ -16,10 +16,10 @@
 
 package controllers
 
-import assets.{ControllerTestSpec, MessageLookup}
 import auth.{AuthorisedActions, CgtNROrganisation}
 import common.Keys.KeystoreKeys
 import connectors.KeystoreConnector
+import data.MessageLookup
 import models._
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
@@ -30,6 +30,7 @@ import play.api.mvc.{Action, AnyContent, Results}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.SubscriptionService
+import traits.ControllerTestSpec
 import types.AuthenticatedNROrganisationAction
 import uk.gov.hmrc.play.frontend.auth.AuthContext
 

--- a/test/controllers/CorrespondenceAddressFinalConfirmationControllerSpec.scala
+++ b/test/controllers/CorrespondenceAddressFinalConfirmationControllerSpec.scala
@@ -31,7 +31,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.SubscriptionService
 import traits.ControllerTestSpec
-import types.AuthenticatedNROrganisationAction
+import auth.AuthenticatedNROrganisationAction
 import uk.gov.hmrc.play.frontend.auth.AuthContext
 
 import scala.concurrent.Future

--- a/test/controllers/EnterCorrespondenceAddressControllerSpec.scala
+++ b/test/controllers/EnterCorrespondenceAddressControllerSpec.scala
@@ -16,11 +16,10 @@
 
 package controllers
 
-import assets.{ControllerTestSpec, MessageLookup}
 import auth.{AuthorisedActions, CgtNROrganisation}
-import builders.TestUserBuilder
 import config.{AppConfig, BusinessCustomerSessionCache, SubscriptionSessionCache}
 import connectors.KeystoreConnector
+import data.{MessageLookup, TestUserBuilder}
 import forms.CorrespondenceAddressForm
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
@@ -30,6 +29,7 @@ import org.mockito.stubbing.Answer
 import play.api.mvc.{Action, AnyContent, Results}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import traits.ControllerTestSpec
 import types.AuthenticatedNROrganisationAction
 import uk.gov.hmrc.play.frontend.auth.AuthContext
 

--- a/test/controllers/EnterCorrespondenceAddressControllerSpec.scala
+++ b/test/controllers/EnterCorrespondenceAddressControllerSpec.scala
@@ -30,7 +30,7 @@ import play.api.mvc.{Action, AnyContent, Results}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import traits.ControllerTestSpec
-import types.AuthenticatedNROrganisationAction
+import auth.AuthenticatedNROrganisationAction
 import uk.gov.hmrc.play.frontend.auth.AuthContext
 
 class EnterCorrespondenceAddressControllerSpec extends ControllerTestSpec {

--- a/test/controllers/FeedbackControllerSpec.scala
+++ b/test/controllers/FeedbackControllerSpec.scala
@@ -16,7 +16,6 @@
 
 package controllers
 
-import assets.ControllerTestSpec
 import config.WSHttp
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
@@ -25,6 +24,7 @@ import play.api.mvc.RequestHeader
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.twirl.api.Html
+import traits.ControllerTestSpec
 import uk.gov.hmrc.play.http.{HttpGet, HttpResponse}
 import uk.gov.hmrc.play.partials.{CachedStaticHtmlPartialRetriever, FormPartialRetriever}
 

--- a/test/controllers/IncorrectAffinityGroupControllerSpec.scala
+++ b/test/controllers/IncorrectAffinityGroupControllerSpec.scala
@@ -16,14 +16,15 @@
 
 package controllers
 
-import assets.{FakeRequestHelper, MessageLookup}
 import config.AppConfig
+import data.MessageLookup
 import org.jsoup.Jsoup
 import org.scalatest.mock.MockitoSugar
 import play.api.i18n.MessagesApi
 import play.api.inject.Injector
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 import play.api.test.Helpers._
+import traits.FakeRequestHelper
 
 class IncorrectAffinityGroupControllerSpec extends UnitSpec with MockitoSugar with WithFakeApplication with FakeRequestHelper {
 

--- a/test/controllers/NonResidentIndividualSubscriptionControllerSpec.scala
+++ b/test/controllers/NonResidentIndividualSubscriptionControllerSpec.scala
@@ -36,7 +36,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers.redirectLocation
 import services.{AuthorisationService, SubscriptionService}
 import traits.ControllerTestSpec
-import types.AuthenticatedIndividualAction
+import auth.AuthenticatedIndividualAction
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.play.frontend.auth.AuthContext
 import uk.gov.hmrc.play.frontend.auth.connectors.domain._

--- a/test/controllers/NonResidentIndividualSubscriptionControllerSpec.scala
+++ b/test/controllers/NonResidentIndividualSubscriptionControllerSpec.scala
@@ -17,13 +17,12 @@
 package controllers
 
 import akka.util.Timeout
-import assets.ControllerTestSpec
 import auth.{AuthorisedActions, CgtIndividual}
-import builders.TestUserBuilder
 import common.Constants.AffinityGroup
 import common.Keys
 import config.WSHttp
 import connectors.{AuthorisationConnector, SubscriptionConnector}
+import data.TestUserBuilder
 import helpers.EnrolmentToCGTCheck
 import models.{AuthorisationDataModel, Enrolment, SubscriptionReference}
 import org.mockito.ArgumentMatchers
@@ -36,6 +35,7 @@ import play.api.mvc.{Action, AnyContent, Results}
 import play.api.test.FakeRequest
 import play.api.test.Helpers.redirectLocation
 import services.{AuthorisationService, SubscriptionService}
+import traits.ControllerTestSpec
 import types.AuthenticatedIndividualAction
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.play.frontend.auth.AuthContext

--- a/test/controllers/OrganisationTypeControllerSpec.scala
+++ b/test/controllers/OrganisationTypeControllerSpec.scala
@@ -29,7 +29,6 @@ import common.Constants.{AffinityGroup, InvalidUserTypes}
 import data.MessageLookup
 import exceptions.AffinityGroupNotFoundException
 import forms.OrganisationForm
-import models.OrganisationModel
 import services.AuthorisationService
 import traits.FakeRequestHelper
 

--- a/test/controllers/OrganisationTypeControllerSpec.scala
+++ b/test/controllers/OrganisationTypeControllerSpec.scala
@@ -16,7 +16,6 @@
 
 package controllers
 
-import assets.{FakeRequestHelper, MessageLookup}
 import config.AppConfig
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
@@ -27,10 +26,12 @@ import play.api.inject.Injector
 import play.api.test.Helpers._
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 import common.Constants.{AffinityGroup, InvalidUserTypes}
+import data.MessageLookup
 import exceptions.AffinityGroupNotFoundException
 import forms.OrganisationForm
 import models.OrganisationModel
 import services.AuthorisationService
+import traits.FakeRequestHelper
 
 class OrganisationTypeControllerSpec extends UnitSpec with MockitoSugar with WithFakeApplication with FakeRequestHelper {
 

--- a/test/controllers/ResidentIndividualSubscriptionControllerSpec.scala
+++ b/test/controllers/ResidentIndividualSubscriptionControllerSpec.scala
@@ -16,13 +16,12 @@
 
 package controllers
 
-import assets.ControllerTestSpec
 import auth.{AuthorisedActions, CgtIndividual}
-import builders.TestUserBuilder
 import common.Constants.AffinityGroup
 import common.Keys
 import config.WSHttp
 import connectors.{AuthorisationConnector, SubscriptionConnector}
+import data.TestUserBuilder
 import helpers.EnrolmentToCGTCheck
 import models.{AuthorisationDataModel, Enrolment, Identifier, SubscriptionReference}
 import org.mockito.ArgumentMatchers
@@ -34,6 +33,7 @@ import play.api.mvc._
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.{AuthorisationService, SubscriptionService}
+import traits.ControllerTestSpec
 import types.AuthenticatedIndividualAction
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.play.frontend.auth.AuthContext

--- a/test/controllers/ResidentIndividualSubscriptionControllerSpec.scala
+++ b/test/controllers/ResidentIndividualSubscriptionControllerSpec.scala
@@ -34,7 +34,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.{AuthorisationService, SubscriptionService}
 import traits.ControllerTestSpec
-import types.AuthenticatedIndividualAction
+import auth.AuthenticatedIndividualAction
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.play.frontend.auth.AuthContext
 import uk.gov.hmrc.play.frontend.auth.connectors.domain.{Accounts, ConfidenceLevel, CredentialStrength, PayeAccount}

--- a/test/controllers/UserDetailsControllerSpec.scala
+++ b/test/controllers/UserDetailsControllerSpec.scala
@@ -14,6 +14,22 @@
  * limitations under the License.
  */
 
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import auth.{AuthorisedActions, CgtIndividual}
@@ -30,7 +46,7 @@ import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.SubscriptionService
 import traits.ControllerTestSpec
-import types.AuthenticatedIndividualAction
+import auth.AuthenticatedIndividualAction
 import uk.gov.hmrc.play.frontend.auth.AuthContext
 import uk.gov.hmrc.play.http.HeaderCarrier
 

--- a/test/controllers/UserDetailsControllerSpec.scala
+++ b/test/controllers/UserDetailsControllerSpec.scala
@@ -16,11 +16,10 @@
 
 package controllers
 
-import assets.{ControllerTestSpec, MessageLookup}
 import auth.{AuthorisedActions, CgtIndividual}
-import builders.TestUserBuilder
+import data.{MessageLookup, TestUserBuilder}
 import forms.UserFactsForm
-import models.{UserFactsModel, SubscriptionReference}
+import models.{SubscriptionReference, UserFactsModel}
 import org.jsoup.Jsoup
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
@@ -30,6 +29,7 @@ import play.api.mvc.{Action, AnyContent, Results}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import services.SubscriptionService
+import traits.ControllerTestSpec
 import types.AuthenticatedIndividualAction
 import uk.gov.hmrc.play.frontend.auth.AuthContext
 import uk.gov.hmrc.play.http.HeaderCarrier

--- a/test/controllers/UserDetailsControllerSpec.scala
+++ b/test/controllers/UserDetailsControllerSpec.scala
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * Copyright 2017 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package controllers
 
 import auth.{AuthorisedActions, CgtIndividual}

--- a/test/data/MessageLookup.scala
+++ b/test/data/MessageLookup.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package assets
+package data
 
 object MessageLookup {
 

--- a/test/data/TestUserBuilder.scala
+++ b/test/data/TestUserBuilder.scala
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package builders
+package data
 
 import uk.gov.hmrc.domain.{Generator, Nino}
 import uk.gov.hmrc.play.frontend.auth.AuthContext
-import uk.gov.hmrc.play.frontend.auth.connectors.domain.{Accounts, Authority, ConfidenceLevel, CredentialStrength, PayeAccount}
+import uk.gov.hmrc.play.frontend.auth.connectors.domain._
 
 import scala.util.Random
 

--- a/test/forms/ContactDetailsFormSpec.scala
+++ b/test/forms/ContactDetailsFormSpec.scala
@@ -16,7 +16,7 @@
 
 package forms
 
-import assets.MessageLookup.Errors
+import data.MessageLookup.Errors
 import models.ContactDetailsModel
 import org.scalatestplus.play.OneAppPerSuite
 import uk.gov.hmrc.play.test.UnitSpec

--- a/test/forms/CorrespondenceAddressFormSpec.scala
+++ b/test/forms/CorrespondenceAddressFormSpec.scala
@@ -16,7 +16,7 @@
 
 package forms
 
-import assets.MessageLookup.Errors
+import data.MessageLookup.Errors
 import models.CompanyAddressModel
 import org.scalatestplus.play.OneAppPerSuite
 import uk.gov.hmrc.play.test.UnitSpec

--- a/test/forms/FullDetailsFormSpec.scala
+++ b/test/forms/FullDetailsFormSpec.scala
@@ -19,7 +19,7 @@ package forms
 import models.UserFactsModel
 import org.scalatestplus.play.OneAppPerSuite
 import uk.gov.hmrc.play.test.UnitSpec
-import assets.MessageLookup.Errors
+import data.MessageLookup.Errors
 
 class FullDetailsFormSpec extends UnitSpec with OneAppPerSuite {
 

--- a/test/forms/OrganisationFormSpec.scala
+++ b/test/forms/OrganisationFormSpec.scala
@@ -19,7 +19,7 @@ package forms
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 import models.OrganisationModel
 import common.Constants.InvalidUserTypes._
-import assets.MessageLookup.{Errors => messages}
+import data.MessageLookup.{Errors => messages}
 import play.api.i18n.MessagesApi
 import play.api.inject.Injector
 

--- a/test/forms/TestForm.scala
+++ b/test/forms/TestForm.scala
@@ -14,16 +14,25 @@
  * limitations under the License.
  */
 
-package assets
+package forms
 
-import config.AppConfig
-import org.scalatestplus.play.OneAppPerSuite
-import play.api.i18n.{I18nSupport, MessagesApi}
-import play.api.inject.Injector
-import uk.gov.hmrc.play.test.UnitSpec
+import common.FormValidation._
+import data.MessageLookup
+import play.api.data.Form
+import play.api.data.Forms.{mapping, text}
 
-trait ViewTestSpec extends UnitSpec with OneAppPerSuite with FakeRequestHelper with I18nSupport {
-  lazy val injector: Injector = app.injector
-  lazy val appConfig: AppConfig = injector.instanceOf[AppConfig]
-  implicit def messagesApi: MessagesApi = injector.instanceOf[MessagesApi]
+object TestForm {
+
+  private val bindingError: TestModel => Boolean = model => model.anotherField == ""
+
+  val testForm = Form(
+    mapping (
+      "response" -> text
+        .verifying(MessageLookup.Errors.dummyError, nonEmptyCheck),
+      "anotherField" -> text
+    )(TestModel.apply)(TestModel.unapply)
+    .verifying(MessageLookup.Errors.dummyError, model => bindingError(model))
+  )
 }
+
+case class TestModel(response: String, anotherField: String)

--- a/test/forms/YesNoFormSpec.scala
+++ b/test/forms/YesNoFormSpec.scala
@@ -16,7 +16,7 @@
 
 package forms
 
-import assets.MessageLookup
+import data.MessageLookup
 import models.YesNoModel
 import org.scalatestplus.play.OneAppPerSuite
 import uk.gov.hmrc.play.test.UnitSpec

--- a/test/helpers/ConfidenceLevelCheckSpec.scala
+++ b/test/helpers/ConfidenceLevelCheckSpec.scala
@@ -16,7 +16,6 @@
 
 package helpers
 
-import uk.gov.hmrc.play.frontend.auth.connectors.domain.ConfidenceLevel
 import uk.gov.hmrc.play.test.UnitSpec
 import data.TestUserBuilder._
 

--- a/test/helpers/ConfidenceLevelCheckSpec.scala
+++ b/test/helpers/ConfidenceLevelCheckSpec.scala
@@ -18,7 +18,7 @@ package helpers
 
 import uk.gov.hmrc.play.frontend.auth.connectors.domain.ConfidenceLevel
 import uk.gov.hmrc.play.test.UnitSpec
-import builders.TestUserBuilder._
+import data.TestUserBuilder._
 
 class ConfidenceLevelCheckSpec extends UnitSpec {
   "Calling .confidenceLevelCheck" should {

--- a/test/helpers/NINOCheckSpec.scala
+++ b/test/helpers/NINOCheckSpec.scala
@@ -17,7 +17,7 @@
 package helpers
 
 import uk.gov.hmrc.play.test.UnitSpec
-import builders.TestUserBuilder._
+import data.TestUserBuilder._
 
 class NINOCheckSpec extends UnitSpec {
 

--- a/test/helpers/StrongCredentialCheckSpec.scala
+++ b/test/helpers/StrongCredentialCheckSpec.scala
@@ -17,7 +17,7 @@
 package helpers
 
 import uk.gov.hmrc.play.test.UnitSpec
-import builders.TestUserBuilder._
+import data.TestUserBuilder._
 
 class StrongCredentialCheckSpec extends UnitSpec {
 

--- a/test/helpers/WeakCredentialCheckSpec.scala
+++ b/test/helpers/WeakCredentialCheckSpec.scala
@@ -17,7 +17,7 @@
 package helpers
 
 import uk.gov.hmrc.play.test.UnitSpec
-import builders.TestUserBuilder._
+import data.TestUserBuilder._
 
 class WeakCredentialCheckSpec extends UnitSpec {
   "Calling .weakCredentialCheck" should {

--- a/test/predicates/AffinityGroupAgentPredicateSpec.scala
+++ b/test/predicates/AffinityGroupAgentPredicateSpec.scala
@@ -18,9 +18,9 @@ package predicates
 
 import java.net.URI
 
-import builders.TestUserBuilder
 import common.Constants.AffinityGroup._
 import connectors.AuthorisationConnector
+import data.TestUserBuilder
 import models.AuthorisationDataModel
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._

--- a/test/predicates/AffinityGroupIndividualPredicateSpec.scala
+++ b/test/predicates/AffinityGroupIndividualPredicateSpec.scala
@@ -20,7 +20,6 @@ import java.net.URI
 
 import play.api.test.FakeRequest
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
-import builders.TestUserBuilder
 import connectors.AuthorisationConnector
 import models.AuthorisationDataModel
 import org.mockito.ArgumentMatchers
@@ -30,6 +29,7 @@ import services.AuthorisationService
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.play.frontend.auth.connectors.domain.{Accounts, ConfidenceLevel, CredentialStrength}
 import common.Constants.AffinityGroup._
+import data.TestUserBuilder
 import uk.gov.hmrc.play.http.HeaderCarrier
 
 import scala.concurrent.Future

--- a/test/predicates/AffinityGroupOrganisationPredicateSpec.scala
+++ b/test/predicates/AffinityGroupOrganisationPredicateSpec.scala
@@ -18,9 +18,9 @@ package predicates
 
 import java.net.URI
 
-import builders.TestUserBuilder
 import common.Constants.AffinityGroup._
 import connectors.AuthorisationConnector
+import data.TestUserBuilder
 import models.AuthorisationDataModel
 import org.mockito.ArgumentMatchers
 import org.scalatest.mock.MockitoSugar

--- a/test/predicates/AgentVisibilityPredicateSpec.scala
+++ b/test/predicates/AgentVisibilityPredicateSpec.scala
@@ -16,10 +16,10 @@
 
 package predicates
 
-import builders.TestUserBuilder
 import common.Constants.AffinityGroup
 import common.Keys
 import config.AppConfig
+import data.TestUserBuilder
 import models.{AuthorisationDataModel, Enrolment, Identifier}
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._

--- a/test/predicates/AgentVisibilityPredicateSpec.scala
+++ b/test/predicates/AgentVisibilityPredicateSpec.scala
@@ -17,10 +17,9 @@
 package predicates
 
 import common.Constants.AffinityGroup
-import common.Keys
 import config.AppConfig
 import data.TestUserBuilder
-import models.{AuthorisationDataModel, Enrolment, Identifier}
+import models.AuthorisationDataModel
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
@@ -28,7 +27,6 @@ import org.scalatestplus.play.OneAppPerSuite
 import play.api.inject.Injector
 import play.api.test.FakeRequest
 import services.AuthorisationService
-import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.play.frontend.auth.connectors.domain.{Accounts, ConfidenceLevel, CredentialStrength, PayeAccount}
 import uk.gov.hmrc.play.test.UnitSpec
 

--- a/test/predicates/IVUpliftPredicateSpec.scala
+++ b/test/predicates/IVUpliftPredicateSpec.scala
@@ -18,7 +18,7 @@ package predicates
 
 import java.net.URI
 
-import builders.TestUserBuilder
+import data.TestUserBuilder
 import play.api.test.FakeRequest
 import uk.gov.hmrc.play.test.UnitSpec
 

--- a/test/predicates/LoginPredicateSpec.scala
+++ b/test/predicates/LoginPredicateSpec.scala
@@ -18,9 +18,9 @@ package predicates
 
 import java.net.URI
 
+import data.TestUserBuilder
 import play.api.test.FakeRequest
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
-import builders.TestUserBuilder
 
 class LoginPredicateSpec extends UnitSpec with WithFakeApplication {
 

--- a/test/predicates/NINOPredicateSpec.scala
+++ b/test/predicates/NINOPredicateSpec.scala
@@ -18,7 +18,7 @@ package predicates
 
 import java.net.URI
 
-import builders.TestUserBuilder
+import data.TestUserBuilder
 import play.api.test.FakeRequest
 import uk.gov.hmrc.play.test.UnitSpec
 

--- a/test/predicates/NonResidentIndividualVisibilityPredicateSpec.scala
+++ b/test/predicates/NonResidentIndividualVisibilityPredicateSpec.scala
@@ -16,10 +16,10 @@
 
 package predicates
 
-import builders.TestUserBuilder
 import common.Constants.AffinityGroup
 import common.Keys
 import config.AppConfig
+import data.TestUserBuilder
 import models.{AuthorisationDataModel, Enrolment, Identifier}
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._

--- a/test/predicates/NonResidentIndividualVisibilityPredicateSpec.scala
+++ b/test/predicates/NonResidentIndividualVisibilityPredicateSpec.scala
@@ -59,7 +59,6 @@ class NonResidentIndividualVisibilityPredicateSpec extends UnitSpec with Mockito
     val notAuthorisedRedirectURI = "http://not-authorised-example.com"
     val twoFactorURI = appConfig.twoFactorUrl
     val authorisationURI = "http://authorisation-uri-example.com"
-    val enrolmentURI = "http://sample-enrolment-uri.com"
 
     implicit val fakeRequest = FakeRequest()
 

--- a/test/predicates/NonResidentOrganisationVisibilityPredicateSpec.scala
+++ b/test/predicates/NonResidentOrganisationVisibilityPredicateSpec.scala
@@ -16,8 +16,8 @@
 
 package predicates
 
-import builders.TestUserBuilder
 import common.Constants.AffinityGroup
+import data.TestUserBuilder
 import models.AuthorisationDataModel
 import org.mockito.ArgumentMatchers
 import org.scalatest.mock.MockitoSugar

--- a/test/predicates/ResidentIndividualVisibilityPredicateSpec.scala
+++ b/test/predicates/ResidentIndividualVisibilityPredicateSpec.scala
@@ -16,7 +16,6 @@
 
 package predicates
 
-import builders.TestUserBuilder
 import play.api.test.FakeRequest
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 import config.AppConfig
@@ -32,6 +31,7 @@ import org.scalatest.mock.MockitoSugar
 import uk.gov.hmrc.play.frontend.auth.connectors.domain.{Accounts, ConfidenceLevel, CredentialStrength, PayeAccount}
 import common.Constants.AffinityGroup
 import common.Keys
+import data.TestUserBuilder
 import uk.gov.hmrc.play.http.HeaderCarrier
 
 import scala.concurrent.Future

--- a/test/predicates/ResidentIndividualVisibilityPredicateSpec.scala
+++ b/test/predicates/ResidentIndividualVisibilityPredicateSpec.scala
@@ -20,8 +20,6 @@ import play.api.test.FakeRequest
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 import config.AppConfig
 import models.{AuthorisationDataModel, Enrolment, Identifier}
-import org.mockito.ArgumentMatchers
-import org.mockito.Mockito._
 import play.api.inject.Injector
 import services.AuthorisationService
 import uk.gov.hmrc.domain.Nino

--- a/test/predicates/TwoFAPredicateSpec.scala
+++ b/test/predicates/TwoFAPredicateSpec.scala
@@ -18,9 +18,9 @@ package predicates
 
 import java.net.URI
 
+import data.TestUserBuilder
 import play.api.test.FakeRequest
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
-import builders.TestUserBuilder
 
 class TwoFAPredicateSpec  extends UnitSpec with WithFakeApplication {
 

--- a/test/services/IdentityVerificationServiceSpec.scala
+++ b/test/services/IdentityVerificationServiceSpec.scala
@@ -16,9 +16,9 @@
 
 package services
 
+import common.IdentityVerificationResult
+import common.IdentityVerificationResult._
 import connectors.IdentityVerificationConnector
-import enums.IdentityVerificationResult
-import enums.IdentityVerificationResult.IdentityVerificationResult
 import org.mockito.ArgumentMatchers
 import org.scalatest.mock.MockitoSugar
 import uk.gov.hmrc.play.test.UnitSpec

--- a/test/traits/ControllerTestSpec.scala
+++ b/test/traits/ControllerTestSpec.scala
@@ -14,24 +14,21 @@
  * limitations under the License.
  */
 
-package assets
+package traits
 
-import play.api.data.Form
-import play.api.data.Forms.{mapping, text}
-import common.FormValidation._
+import akka.stream.Materializer
+import config.AppConfig
+import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.play.OneAppPerSuite
+import play.api.i18n.MessagesApi
+import uk.gov.hmrc.play.test.UnitSpec
 
-object TestForm {
 
-  private val bindingError: TestModel => Boolean = model => model.anotherField == ""
+trait ControllerTestSpec extends UnitSpec with MockitoSugar with OneAppPerSuite {
 
-  val testForm = Form(
-    mapping (
-      "response" -> text
-        .verifying(MessageLookup.Errors.dummyError, nonEmptyCheck),
-      "anotherField" -> text
-    )(TestModel.apply)(TestModel.unapply)
-    .verifying(MessageLookup.Errors.dummyError, model => bindingError(model))
-  )
+  val mockConfig: AppConfig = app.injector.instanceOf[AppConfig]
+  val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
+
+  implicit val mat: Materializer = app.injector.instanceOf[Materializer]
+
 }
-
-case class TestModel(response: String, anotherField: String)

--- a/test/traits/FakeRequestHelper.scala
+++ b/test/traits/FakeRequestHelper.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package assets
+package traits
 
 import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded}
 import play.api.test.FakeRequest

--- a/test/traits/ViewTestSpec.scala
+++ b/test/traits/ViewTestSpec.scala
@@ -14,21 +14,16 @@
  * limitations under the License.
  */
 
-package assets
+package traits
 
-import akka.stream.Materializer
 import config.AppConfig
-import org.scalatest.mock.MockitoSugar
 import org.scalatestplus.play.OneAppPerSuite
-import play.api.i18n.MessagesApi
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.inject.Injector
 import uk.gov.hmrc.play.test.UnitSpec
 
-
-trait ControllerTestSpec extends UnitSpec with MockitoSugar with OneAppPerSuite {
-
-  val mockConfig: AppConfig = app.injector.instanceOf[AppConfig]
-  val messagesApi: MessagesApi = app.injector.instanceOf[MessagesApi]
-
-  implicit val mat: Materializer = app.injector.instanceOf[Materializer]
-
+trait ViewTestSpec extends UnitSpec with OneAppPerSuite with FakeRequestHelper with I18nSupport {
+  lazy val injector: Injector = app.injector
+  lazy val appConfig: AppConfig = injector.instanceOf[AppConfig]
+  implicit def messagesApi: MessagesApi = injector.instanceOf[MessagesApi]
 }

--- a/test/views/ContactDetailsViewSpec.scala
+++ b/test/views/ContactDetailsViewSpec.scala
@@ -16,10 +16,10 @@
 
 package views
 
-import assets.MessageLookup.{Common, ContactDetails => messages}
-import assets.ViewTestSpec
+import data.MessageLookup.{Common, ContactDetails => messages}
 import forms.ContactDetailsForm
 import org.jsoup.Jsoup
+import traits.ViewTestSpec
 import views.html.contactDetails
 
 class ContactDetailsViewSpec extends ViewTestSpec {

--- a/test/views/IncorrectAffinityGroupViewSpec.scala
+++ b/test/views/IncorrectAffinityGroupViewSpec.scala
@@ -16,15 +16,15 @@
 
 package views
 
-import assets.FakeRequestHelper
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
-import assets.MessageLookup.{InvalidAffinityGroup => messages}
+import data.MessageLookup.{InvalidAffinityGroup => messages}
 import config.AppConfig
 import org.jsoup._
 import org.scalatest.mock.MockitoSugar
 import views.html.errors.errorInvalidUser
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.inject.Injector
+import traits.FakeRequestHelper
 
 class IncorrectAffinityGroupViewSpec extends UnitSpec with WithFakeApplication with FakeRequestHelper with MockitoSugar with I18nSupport {
 

--- a/test/views/OrganisationTypeViewSpec.scala
+++ b/test/views/OrganisationTypeViewSpec.scala
@@ -16,17 +16,17 @@
 
 package views
 
-import assets.FakeRequestHelper
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 import common.Constants.InvalidUserTypes
-import assets.MessageLookup.{OrganisationType => messages}
-import assets.MessageLookup.{Common => commonMessages}
+import data.MessageLookup.{OrganisationType => messages}
+import data.MessageLookup.{Common => commonMessages}
 import config.AppConfig
 import forms.OrganisationForm
 import org.scalatest.mock.MockitoSugar
 import org.jsoup.Jsoup
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.inject.Injector
+import traits.FakeRequestHelper
 
 class OrganisationTypeViewSpec extends UnitSpec with WithFakeApplication with FakeRequestHelper with MockitoSugar with I18nSupport {
 

--- a/test/views/ReviewBusinessDetailsViewSpec.scala
+++ b/test/views/ReviewBusinessDetailsViewSpec.scala
@@ -16,8 +16,8 @@
 
 package views
 
-import assets.{FakeRequestHelper, MessageLookup}
 import config.AppConfig
+import data.MessageLookup
 import models.{CompanyAddressModel, ContactDetailsModel}
 import org.jsoup.Jsoup
 import org.scalatestplus.play.OneAppPerSuite
@@ -25,7 +25,8 @@ import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.inject.Injector
 import uk.gov.hmrc.play.test.UnitSpec
 import views.html.reviewBusinessDetails
-import assets.MessageLookup.{ReviewBusinessDetails => messages}
+import data.MessageLookup.{ReviewBusinessDetails => messages}
+import traits.FakeRequestHelper
 
 
 class ReviewBusinessDetailsViewSpec extends UnitSpec with OneAppPerSuite with FakeRequestHelper with I18nSupport {

--- a/test/views/SetupYourAgencyViewSpec.scala
+++ b/test/views/SetupYourAgencyViewSpec.scala
@@ -16,9 +16,10 @@
 
 package views
 
-import assets.{MessageLookup, ViewTestSpec}
-import assets.MessageLookup.SetupYourAgency._
+import data.MessageLookup
+import data.MessageLookup.SetupYourAgency._
 import org.jsoup.Jsoup
+import traits.ViewTestSpec
 import views.html.setupYourAgency
 
 class SetupYourAgencyViewSpec extends ViewTestSpec {

--- a/test/views/UseRegisteredAddressViewSpec.scala
+++ b/test/views/UseRegisteredAddressViewSpec.scala
@@ -16,12 +16,12 @@
 
 package views
 
-import assets.ViewTestSpec
 import forms.YesNoForm
 import org.jsoup.Jsoup
 import views.html.useRegisteredAddress
-import assets.MessageLookup.{Common, UseRegisteredAddress}
+import data.MessageLookup.{Common, UseRegisteredAddress}
 import models.CompanyAddressModel
+import traits.ViewTestSpec
 
 class UseRegisteredAddressViewSpec extends ViewTestSpec {
 

--- a/test/views/UserDetailsViewSpec.scala
+++ b/test/views/UserDetailsViewSpec.scala
@@ -16,15 +16,15 @@
 
 package views
 
-import assets.FakeRequestHelper
-import assets.MessageLookup.UserDetails
-import assets.MessageLookup.Common
+import data.MessageLookup.UserDetails
+import data.MessageLookup.Common
 import config.AppConfig
 import forms.UserFactsForm
 import org.jsoup.Jsoup
 import org.scalatestplus.play.OneAppPerSuite
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.inject.Injector
+import traits.FakeRequestHelper
 import uk.gov.hmrc.play.test.UnitSpec
 import views.html.userDetails
 

--- a/test/views/address/EnterCorrespondenceAddressViewSpec.scala
+++ b/test/views/address/EnterCorrespondenceAddressViewSpec.scala
@@ -16,14 +16,14 @@
 
 package views.address
 
-import assets.FakeRequestHelper
-import assets.MessageLookup.{Common, EnterCorrespondenceAddress}
+import data.MessageLookup.{Common, EnterCorrespondenceAddress}
 import config.AppConfig
 import forms.CorrespondenceAddressForm
 import org.jsoup.Jsoup
 import org.scalatestplus.play.OneAppPerSuite
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.inject.Injector
+import traits.FakeRequestHelper
 import uk.gov.hmrc.play.test.UnitSpec
 import views.html.address.enterCorrespondenceAddress
 

--- a/test/views/confirmation/AgentSubscriptionConfirmationViewSpec.scala
+++ b/test/views/confirmation/AgentSubscriptionConfirmationViewSpec.scala
@@ -19,10 +19,10 @@ package views.confirmation
 import java.time.LocalDate
 import java.time.format.{DateTimeFormatter, ResolverStyle}
 
-import assets.ViewTestSpec
 import org.jsoup.Jsoup
 import views.html.confirmation.agentSubscriptionConfirmation
-import assets.MessageLookup.{AgentConfirmation => messages}
+import data.MessageLookup.{AgentConfirmation => messages}
+import traits.ViewTestSpec
 
 class AgentSubscriptionConfirmationViewSpec extends ViewTestSpec {
 

--- a/test/views/confirmation/CGTSubscriptionConfirmationViewSpec.scala
+++ b/test/views/confirmation/CGTSubscriptionConfirmationViewSpec.scala
@@ -16,16 +16,15 @@
 
 package views.confirmation
 
-
-import assets.FakeRequestHelper
-import assets.MessageLookup.{CGTSubscriptionConfirm => messages}
-import assets.MessageLookup.{Common => commonMessages}
+import data.MessageLookup.{CGTSubscriptionConfirm => messages}
+import data.MessageLookup.{Common => commonMessages}
 import config.AppConfig
 import org.jsoup._
 import org.scalatest.mock.MockitoSugar
 import views.html.confirmation.cgtSubscriptionConfirmation
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.inject.Injector
+import traits.FakeRequestHelper
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 
 class CGTSubscriptionConfirmationViewSpec extends UnitSpec with WithFakeApplication with FakeRequestHelper with MockitoSugar with I18nSupport {

--- a/test/views/helpers/ErrorSummaryViewSpec.scala
+++ b/test/views/helpers/ErrorSummaryViewSpec.scala
@@ -16,11 +16,11 @@
 
 package views.helpers
 
-import assets.MessageLookup.{ErrorSummary => messages}
-import assets.MessageLookup.{Errors => errorMessages}
+import data.MessageLookup.{ErrorSummary => messages}
+import data.MessageLookup.{Errors => errorMessages}
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 import views.html.helpers.{errorSummary => view}
-import assets.TestForm._
+import forms.TestForm._
 import org.jsoup.Jsoup
 import play.api.i18n.{I18nSupport, MessagesApi}
 


### PR DESCRIPTION
- Moved 'types' package object for Authenticated types to the Auth package, removed types package
- Moved enums object to common and stripped out 'enum' package
- Split out 'assets' package into a 'traits' and 'data' package
- Mass-updating of imports