### PR TITLE
Made all checks standard objects

### DIFF
--- a/app/controllers/AgentController.scala
+++ b/app/controllers/AgentController.scala
@@ -40,7 +40,6 @@ class AgentController @Inject()(appConfig: AppConfig,
                                 agentService: AgentService,
                                 sessionService: KeystoreConnector,
                                 authService: AuthorisationService,
-                                enrolmentToCGTCheck: EnrolmentToCGTCheck,
                                 subscriptionService: SubscriptionService,
                                 val messagesApi: MessagesApi) extends FrontendController with I18nSupport {
 
@@ -59,7 +58,7 @@ class AgentController @Inject()(appConfig: AppConfig,
 
         for {
           enrolments <- authService.getEnrolments
-          isEnrolled <- enrolmentToCGTCheck.checkAgentEnrolments(enrolments)
+          isEnrolled <- EnrolmentToCGTCheck.checkAgentEnrolments(enrolments)
           redirect <- checkForEnrolmentAndRedirectToConfirmationOrAlreadyEnrolled(user, isEnrolled)
         } yield redirect
   }

--- a/app/controllers/CompanyController.scala
+++ b/app/controllers/CompanyController.scala
@@ -30,8 +30,7 @@ import scala.concurrent.Future
 @Singleton
 class CompanyController @Inject()(appConfig: AppConfig,
                                   authorisedActions: AuthorisedActions,
-                                  authService: AuthorisationService,
-                                  enrolmentToCGTCheck: EnrolmentToCGTCheck) extends FrontendController {
+                                  authService: AuthorisationService) extends FrontendController {
 
   val businessCustomerFrontendUrl: String = appConfig.businessCompanyFrontendRegister
 
@@ -46,7 +45,7 @@ class CompanyController @Inject()(appConfig: AppConfig,
 
         for {
           enrolments <- authService.getEnrolments
-          isEnrolled <- enrolmentToCGTCheck.checkEnrolments(enrolments)
+          isEnrolled <- EnrolmentToCGTCheck.checkEnrolments(enrolments)
           redirect <- checkForEnrolmentsAndRedirect(user, isEnrolled)
         } yield redirect
 

--- a/app/controllers/NonResidentIndividualSubscriptionController.scala
+++ b/app/controllers/NonResidentIndividualSubscriptionController.scala
@@ -30,8 +30,7 @@ import scala.concurrent.Future
 class NonResidentIndividualSubscriptionController @Inject()(actions: AuthorisedActions,
                                                             appConfig: AppConfig,
                                                             subscriptionService: SubscriptionService,
-                                                            authorisationService: AuthorisationService,
-                                                            enrolmentToCGTCheck: EnrolmentToCGTCheck)
+                                                            authorisationService: AuthorisationService)
   extends FrontendController {
 
   val nonResidentIndividualSubscription: Action[AnyContent] = actions.authorisedNonResidentIndividualAction {
@@ -39,7 +38,7 @@ class NonResidentIndividualSubscriptionController @Inject()(actions: AuthorisedA
       implicit request =>
         for {
           enrolments <- authorisationService.getEnrolments(hc(request))
-          checkEnrolled <- enrolmentToCGTCheck.checkEnrolments(enrolments)
+          checkEnrolled <- EnrolmentToCGTCheck.checkEnrolments(enrolments)
           route <- routeRequest(checkEnrolled)
         } yield route
   }

--- a/app/controllers/ResidentIndividualSubscriptionController.scala
+++ b/app/controllers/ResidentIndividualSubscriptionController.scala
@@ -33,9 +33,7 @@ import scala.concurrent.Future
 class ResidentIndividualSubscriptionController @Inject()(actions: AuthorisedActions,
                                                          appConfig: AppConfig,
                                                          subscriptionService: SubscriptionService,
-                                                         authService: AuthorisationService,
-                                                         enrolmentToCGTCheck: EnrolmentToCGTCheck)
-  extends FrontendController {
+                                                         authService: AuthorisationService) extends FrontendController {
 
   val residentIndividualSubscription: Action[AnyContent] =
     actions.authorisedResidentIndividualAction {
@@ -43,7 +41,7 @@ class ResidentIndividualSubscriptionController @Inject()(actions: AuthorisedActi
         implicit request =>
           for {
             enrolments <- authService.getEnrolments
-            isEnrolled <- enrolmentToCGTCheck.checkEnrolments(enrolments)
+            isEnrolled <- EnrolmentToCGTCheck.checkEnrolments(enrolments)
             redirect <- checkForEnrolmentAndRedirectToConfirmationOrAlreadyEnrolled(user, isEnrolled)
           } yield redirect
     }

--- a/app/helpers/AffinityGroupCheck.scala
+++ b/app/helpers/AffinityGroupCheck.scala
@@ -19,14 +19,10 @@ package helpers
 import scala.concurrent.Future
 import common.Constants.AffinityGroup._
 
-object AffinityGroupCheck extends AffinityGroupCheck
-
-trait AffinityGroupCheck {
-
+object AffinityGroupCheck {
   def affinityGroupCheckIndividual(affinityGroup: String): Future[Boolean] = Future.successful(affinityGroup == Individual)
 
   def affinityGroupCheckCompany(affinityGroup: String): Future[Boolean] = Future.successful(affinityGroup == Organisation)
 
   def affinityGroupCheckAgent(affinityGroup: String): Future[Boolean] = Future.successful(affinityGroup == Agent)
-
 }

--- a/app/helpers/ConfidenceLevelCheck.scala
+++ b/app/helpers/ConfidenceLevelCheck.scala
@@ -21,9 +21,7 @@ import uk.gov.hmrc.play.frontend.auth.connectors.domain.ConfidenceLevel
 
 import scala.concurrent.Future
 
-object ConfidenceLevelCheck extends ConfidenceLevelCheck
-
-trait ConfidenceLevelCheck {
+object ConfidenceLevelCheck {
   def confidenceLevelCheck(authContext: AuthContext): Future[Boolean] = authContext.user.confidenceLevel match {
     case ConfidenceLevel.L200 => Future.successful(true)
     case ConfidenceLevel.L300 => Future.successful(true)

--- a/app/helpers/EnrolmentToCGTCheck.scala
+++ b/app/helpers/EnrolmentToCGTCheck.scala
@@ -16,14 +16,12 @@
 
 package helpers
 
-import javax.inject.Inject
-
 import common.Keys
 import models.Enrolment
 
 import scala.concurrent.Future
 
-class EnrolmentToCGTCheck @Inject()() {
+object EnrolmentToCGTCheck {
   def checkEnrolments(enrolments: Option[Seq[Enrolment]]): Future[Boolean] = enrolments match {
     case Some(data) => Future.successful(data.exists(_.key == Keys.cGTEnrolmentKey))
     case None => Future.successful(false)

--- a/app/helpers/NINOCheck.scala
+++ b/app/helpers/NINOCheck.scala
@@ -19,8 +19,6 @@ package helpers
 import uk.gov.hmrc.play.frontend.auth.AuthContext
 import scala.concurrent.Future
 
-object NINOCheck extends NINOCheck
-
-trait NINOCheck {
+object NINOCheck {
   def checkNINO(authContext: AuthContext): Future[Boolean] = Future.successful(authContext.principal.accounts.paye.isDefined)
 }

--- a/app/helpers/StrongCredentialCheck.scala
+++ b/app/helpers/StrongCredentialCheck.scala
@@ -21,11 +21,7 @@ import uk.gov.hmrc.play.frontend.auth.connectors.domain.CredentialStrength
 
 import scala.concurrent.Future
 
-object StrongCredentialCheck extends StrongCredentialCheck
-
-trait StrongCredentialCheck {
-
+object StrongCredentialCheck {
   def checkCredential(authContext: AuthContext): Future[Boolean] = Future.successful(authContext.user.credentialStrength == CredentialStrength.Strong)
-
 }
 

--- a/app/helpers/WeakCredentialCheck.scala
+++ b/app/helpers/WeakCredentialCheck.scala
@@ -21,9 +21,7 @@ import uk.gov.hmrc.play.frontend.auth.connectors.domain.CredentialStrength
 
 import scala.concurrent.Future
 
-object WeakCredentialCheck extends WeakCredentialCheck
-
-trait WeakCredentialCheck {
+object WeakCredentialCheck {
   def weakCredentialCheck(authContext: AuthContext): Future[Boolean] = authContext.user.credentialStrength match {
     case CredentialStrength.None => Future.successful(false)
     case _ => Future.successful(true)

--- a/test/controllers/AgentControllerSpec.scala
+++ b/test/controllers/AgentControllerSpec.scala
@@ -50,9 +50,6 @@ class AgentControllerSpec extends ControllerTestSpec {
 
   val testOnlyUnauthorisedLoginUri = "just-a-test"
 
-  val injector: Injector = app.injector
-  val enrolmentToCGTCheck: EnrolmentToCGTCheck = injector.instanceOf[EnrolmentToCGTCheck]
-
   object TestData {
     val businessAddress = Address(line_1 = "",
       line_2 = "",
@@ -138,7 +135,7 @@ class AgentControllerSpec extends ControllerTestSpec {
     when(sessionService.fetchAndGetBusinessData()(any())).thenReturn(Future.successful(businessDetails))
     when(service.getAgentEnrolmentResponse(any())(any())).thenReturn(Future.successful(enrolmentResponse))
 
-    new AgentController(mockConfig, mockActions, service, sessionService, mockAuthorisationService, enrolmentToCGTCheck, mockSubscriptionService, messagesApi)
+    new AgentController(mockConfig, mockActions, service, sessionService, mockAuthorisationService, mockSubscriptionService, messagesApi)
 
   }
 

--- a/test/controllers/CompanyControllerSpec.scala
+++ b/test/controllers/CompanyControllerSpec.scala
@@ -44,9 +44,6 @@ class CompanyControllerSpec extends ControllerTestSpec {
 
   val testOnlyUnauthorisedLoginUri = "just-a-test"
 
-  val injector: Injector = app.injector
-  val enrolmentToCGTCheck: EnrolmentToCGTCheck = injector.instanceOf[EnrolmentToCGTCheck]
-
   def createMockActions(valid: Boolean = false, authContext: AuthContext = TestUserBuilder.strongUserAuthContext): AuthorisedActions = {
 
     val mockActions = mock[AuthorisedActions]
@@ -94,7 +91,7 @@ class CompanyControllerSpec extends ControllerTestSpec {
     "the company is authorised and unenrolled" should {
       val enrolments = Option(Seq(Enrolment("key", Seq(), "")))
       lazy val authService = mockAuthorisationService(enrolments, authorisationDataModelPass)
-      lazy val companyController: CompanyController = new CompanyController(mockConfig, action, authService, enrolmentToCGTCheck)
+      lazy val companyController: CompanyController = new CompanyController(mockConfig, action, authService)
       lazy val result = await(companyController.subscribe(fakeRequest))
 
       "return a status of 303" in {
@@ -108,7 +105,7 @@ class CompanyControllerSpec extends ControllerTestSpec {
     "the company is authorised and enrolled" should {
       lazy val enrolments = Option(Seq(Enrolment(Keys.cGTEnrolmentKey, Seq(), ""), Enrolment("key", Seq(), "")))
       lazy val authService = mockAuthorisationService(enrolments, authorisationDataModelPass)
-      lazy val companyController: CompanyController = new CompanyController(mockConfig, action, authService, enrolmentToCGTCheck)
+      lazy val companyController: CompanyController = new CompanyController(mockConfig, action, authService)
       lazy val result = await(companyController.subscribe(fakeRequest))
       "return a status of 303" in {
         status(result) shouldBe 303
@@ -128,7 +125,7 @@ class CompanyControllerSpec extends ControllerTestSpec {
       val enrolments = Option(Seq(Enrolment("key", Seq(), "")))
       lazy val authService = mockAuthorisationService(enrolments, authorisationDataModelFail)
 
-      lazy val companyController: CompanyController = new CompanyController(mockConfig, action, authService, enrolmentToCGTCheck)
+      lazy val companyController: CompanyController = new CompanyController(mockConfig, action, authService)
       lazy val result = await(companyController.subscribe(fakeRequest))
 
       "return a status of 303" in {

--- a/test/controllers/NonResidentIndividualSubscriptionControllerSpec.scala
+++ b/test/controllers/NonResidentIndividualSubscriptionControllerSpec.scala
@@ -47,9 +47,6 @@ class NonResidentIndividualSubscriptionControllerSpec extends ControllerTestSpec
 
   val unauthorisedLoginUri = "some-url"
 
-  val injector: Injector = app.injector
-  val enrolmentToCGTCheck: EnrolmentToCGTCheck = injector.instanceOf[EnrolmentToCGTCheck]
-
   implicit val timeout: Timeout = mock[Timeout]
 
   def createMockActions(valid: Boolean = false, authContext: AuthContext = TestUserBuilder.userWithNINO): AuthorisedActions = {
@@ -121,7 +118,7 @@ class NonResidentIndividualSubscriptionControllerSpec extends ControllerTestSpec
       lazy val mockAuthorisationService = createMockAuthorisationService(Some(enrolments), Some(authorisationDataModelPass))
 
       lazy val target = new NonResidentIndividualSubscriptionController(mockActions, mockConfig, mockSubscriptionService,
-        mockAuthorisationService, enrolmentToCGTCheck)
+        mockAuthorisationService)
 
       lazy val result = target.nonResidentIndividualSubscription(fakeRequest)
 
@@ -144,7 +141,7 @@ class NonResidentIndividualSubscriptionControllerSpec extends ControllerTestSpec
       lazy val mockAuthorisationService = createMockAuthorisationService(Some(enrolments), Some(authorisationDataModelPass))
 
       lazy val target = new NonResidentIndividualSubscriptionController(mockActions, mockConfig, mockSubscriptionService,
-        mockAuthorisationService, enrolmentToCGTCheck)
+        mockAuthorisationService)
 
       lazy val result = target.nonResidentIndividualSubscription(fakeRequest)
 
@@ -166,7 +163,7 @@ class NonResidentIndividualSubscriptionControllerSpec extends ControllerTestSpec
       lazy val mockAuthorisationService = createMockAuthorisationService(Some(enrolments), Some(authorisationDataModelPass))
 
       lazy val target = new NonResidentIndividualSubscriptionController(mockActions, mockConfig, mockSubscriptionService,
-        mockAuthorisationService, enrolmentToCGTCheck)
+        mockAuthorisationService)
 
       lazy val result = target.nonResidentIndividualSubscription(fakeRequest)
 
@@ -190,7 +187,7 @@ class NonResidentIndividualSubscriptionControllerSpec extends ControllerTestSpec
       lazy val mockAuthorisationService = createMockAuthorisationService(Some(enrolments), Some(authorisationDataModelNoNino))
 
       lazy val target = new NonResidentIndividualSubscriptionController(mockActions, mockConfig, mockSubscriptionService,
-        mockAuthorisationService, enrolmentToCGTCheck)
+        mockAuthorisationService)
 
       lazy val result = target.nonResidentIndividualSubscription(fakeRequest)
 

--- a/test/controllers/ResidentIndividualSubscriptionControllerSpec.scala
+++ b/test/controllers/ResidentIndividualSubscriptionControllerSpec.scala
@@ -45,9 +45,6 @@ class ResidentIndividualSubscriptionControllerSpec extends ControllerTestSpec {
 
   val unauthorisedLoginUri = "some-url"
 
-  val injector: Injector = app.injector
-  val enrolmentToCGTCheck: EnrolmentToCGTCheck = injector.instanceOf[EnrolmentToCGTCheck]
-
   def createMockActions(valid: Boolean = false, authContext: AuthContext = TestUserBuilder.userWithNINO): AuthorisedActions = {
 
     val mockActions = mock[AuthorisedActions]
@@ -117,7 +114,7 @@ class ResidentIndividualSubscriptionControllerSpec extends ControllerTestSpec {
       lazy val authorisationService = createMockAuthorisationService(Some(enrolments), Some(authorisationDataModelPass))
 
       lazy val target = new ResidentIndividualSubscriptionController(actions, mockConfig, mockSubscriptionService,
-        authorisationService, enrolmentToCGTCheck)
+        authorisationService)
 
       lazy val result = target.residentIndividualSubscription(fakeRequest)
 
@@ -139,7 +136,7 @@ class ResidentIndividualSubscriptionControllerSpec extends ControllerTestSpec {
       lazy val authorisationService = createMockAuthorisationService(Some(enrolments), Some(authorisationDataModelPass))
 
       lazy val target = new ResidentIndividualSubscriptionController(actions, mockConfig, mockSubscriptionService,
-        authorisationService, enrolmentToCGTCheck)
+        authorisationService)
 
       lazy val result = target.residentIndividualSubscription(fakeRequest)
 
@@ -160,7 +157,7 @@ class ResidentIndividualSubscriptionControllerSpec extends ControllerTestSpec {
       lazy val authorisationService = createMockAuthorisationService(Some(enrolments), Some(authorisationDataModelPass))
 
       lazy val target = new ResidentIndividualSubscriptionController(actions, mockConfig, mockSubscriptionService,
-        authorisationService, enrolmentToCGTCheck)
+        authorisationService)
       lazy val result = target.residentIndividualSubscription(fakeRequest)
 
       "return a status of 303" in {
@@ -180,7 +177,7 @@ class ResidentIndividualSubscriptionControllerSpec extends ControllerTestSpec {
       lazy val authorisationService = createMockAuthorisationService(Some(enrolments), Some(authorisationDataModelPass))
 
       lazy val target = new ResidentIndividualSubscriptionController(actions, mockConfig, mockSubscriptionService,
-        authorisationService, enrolmentToCGTCheck)
+        authorisationService)
       lazy val result = target.residentIndividualSubscription(fakeRequest)
 
       "return a status of 303" in {
@@ -198,7 +195,7 @@ class ResidentIndividualSubscriptionControllerSpec extends ControllerTestSpec {
       val mockSubscriptionService = createMockSubscriptionService(None)
       lazy val authorisationService = createMockAuthorisationService(None, Some(authorisationDataModelFail))
       lazy val target = new ResidentIndividualSubscriptionController(actions, mockConfig, mockSubscriptionService,
-        authorisationService, enrolmentToCGTCheck)
+        authorisationService)
       lazy val result = target.residentIndividualSubscription(fakeRequest)
 
       "return a status of 303" in {

--- a/test/helpers/EnrolmentToCGTCheckSpec.scala
+++ b/test/helpers/EnrolmentToCGTCheckSpec.scala
@@ -23,13 +23,11 @@ import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 
 class EnrolmentToCGTCheckSpec extends UnitSpec with WithFakeApplication {
 
-  val injector: Injector = fakeApplication.injector
-  val enrolmentToCGTCheck: EnrolmentToCGTCheck = injector.instanceOf[EnrolmentToCGTCheck]
 
   "Calling .checkEnrolments" should {
     "return true when supplied with a single element Sequence of Enrolments that includes the CGT enrolment" in {
       val enrolments = Seq(Enrolment(Keys.cGTEnrolmentKey, Seq(Identifier("DummyKey", "DummyValue")), ""))
-      await(enrolmentToCGTCheck.checkEnrolments(Some(enrolments))) shouldBe true
+      await(EnrolmentToCGTCheck.checkEnrolments(Some(enrolments))) shouldBe true
     }
 
     "return true when supplied with a multiple element Sequence of Enrolments that includes the CGT enrolment" in {
@@ -37,23 +35,23 @@ class EnrolmentToCGTCheckSpec extends UnitSpec with WithFakeApplication {
         Enrolment("Not the CGT Key", Seq(Identifier("DummyKey", "DummyValue")), ""),
         Enrolment(Keys.cGTEnrolmentKey, Seq(Identifier("DummyKey", "DummyValue")), "")
       )
-      await(enrolmentToCGTCheck.checkEnrolments(Some(enrolments))) shouldBe true
+      await(EnrolmentToCGTCheck.checkEnrolments(Some(enrolments))) shouldBe true
       }
 
     "return false when supplied with Sequence of Enrolments that does not include the CGT enrolment" in {
       val enrolments = Seq(Enrolment("Not the CGT Key", Seq(Identifier("DummyKey", "DummyValue")), ""))
-      await(enrolmentToCGTCheck.checkEnrolments(Some(enrolments))) shouldBe false
+      await(EnrolmentToCGTCheck.checkEnrolments(Some(enrolments))) shouldBe false
     }
 
     "return false when supplied with a None" in {
-      await(enrolmentToCGTCheck.checkEnrolments(None)) shouldBe false
+      await(EnrolmentToCGTCheck.checkEnrolments(None)) shouldBe false
     }
   }
 
   "Calling .checkAgentEnrolments" should {
     "return true when supplied with a single element Sequence of Enrolments that includes the Agent CGT enrolment" in {
       val enrolments = Seq(Enrolment(Keys.cgtAgentEnrolmentKey, Seq(Identifier("DummyKey", "DummyValue")),""))
-      await(enrolmentToCGTCheck.checkAgentEnrolments(Some(enrolments))) shouldBe true
+      await(EnrolmentToCGTCheck.checkAgentEnrolments(Some(enrolments))) shouldBe true
     }
 
     "return true when supplied with a multiple element Sequence of Enrolments that includes the Agent CGT enrolment" in {
@@ -61,16 +59,16 @@ class EnrolmentToCGTCheckSpec extends UnitSpec with WithFakeApplication {
         Enrolment("Not the Agent CGT Key", Seq(Identifier("DummyKey", "DummyValue")), ""),
         Enrolment(Keys.cgtAgentEnrolmentKey, Seq(Identifier("DummyKey", "DummyValue")), "")
       )
-      await(enrolmentToCGTCheck.checkAgentEnrolments(Some(enrolments))) shouldBe true
+      await(EnrolmentToCGTCheck.checkAgentEnrolments(Some(enrolments))) shouldBe true
     }
 
     "return false when supplied with a Sequence of Enrolments that does not include the Agent CGT enrolment" in {
       val enrolments = Seq(Enrolment("Not the Agent CGT Key", Seq(Identifier("DummyKey", "DummyValue")), ""))
-      await(enrolmentToCGTCheck.checkAgentEnrolments(Some(enrolments))) shouldBe false
+      await(EnrolmentToCGTCheck.checkAgentEnrolments(Some(enrolments))) shouldBe false
     }
 
     "return false when supplied with a None" in {
-      await(enrolmentToCGTCheck.checkAgentEnrolments(None)) shouldBe false
+      await(EnrolmentToCGTCheck.checkAgentEnrolments(None)) shouldBe false
     }
   }
 }


### PR DESCRIPTION
Stripped out redundant trait object pairings and made CGT enrolment check no longer injectable